### PR TITLE
Package setup with flit + basic CI config

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,24 @@
+name: "CodeQL"
+
+on: push
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
+
+      # Initializes the CodeQL tools for scanning.
+      - name: ⏳ Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: "python"
+
+      - name: 🔬 Analyze code
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,33 @@
+name: "Publish"
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  publish_to_pypi:
+    name: 📦 Publish to PyPi
+    runs-on: ubuntu-latest
+    env:
+      FLIT_USERNAME: ${{ secrets.PYPI_USER }}
+      FLIT_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+          cache: "pip"
+          cache-dependency-path: "**/pyproject.toml"
+      - name: ⬇️ Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[test]
+      - name: 🧪 Run tests
+        run: pytest
+      - name: ⬇️ Install build dependencies
+        run: python -m pip install build  --user
+      - name: 🏗️ Build
+        run: flit build
+      - name: 🚀 Publish
+        run: flit publish

--- a/.github/workflows/test-bleeding-edges.yml
+++ b/.github/workflows/test-bleeding-edges.yml
@@ -1,0 +1,26 @@
+name: "Test bleeding edges"
+
+on:
+  push:
+    branches: [main, "compat/django**", "compat/wagtail**"]
+  schedule:
+    # Run at 4pm every Monday, Wednesday and Friday
+    - cron: "0 16 * * 0,2,4"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+      - run: |
+          python -m pip install --upgrade pip
+          pip install -e .[test]
+          pip install git+https://github.com/wagtail/wagtail.git@main#egg=wagtail
+      - name: "Test against Wagtail main"
+        run: pytest
+      - run: pip install git+https://github.com/django/django.git@main#egg=Django
+      - name: "Test against Django main"
+        run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,76 @@
+name: "Test"
+
+on: push
+
+# Our test suite should cover:
+# - Compatibility with the most recent versions of Wagtail and Django
+# - Compatibility with each version of Wagtail we support, changing the Django version where possible for some additional reassurance of Django compatibility
+
+jobs:
+  lint:
+    name: 🧹 Lint Python
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+          cache: "pip"
+          cache-dependency-path: "**/pyproject.toml"
+      - run: |
+          python -m pip install --upgrade pip
+          pip install -e .[lint]
+      - name: Run flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Run isort
+        run: isort . --check-only --diff
+      - name: Run black
+        run: black . --check --fast
+
+  test:
+    name: 🧪 Test Python
+    needs: lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - wagtail-version: "Wagtail>=3.0,<4.0"
+            django-version: "Django>=4.0,<5.0"
+            python-version: 3.9
+            latest: true
+          - wagtail-version: "Wagtail>=2.16,<3.0"
+            django-version: "Django>=3.2,<4.0"
+            python-version: 3.9
+          - wagtail-version: "Wagtail>=2.15,<2.16"
+            django-version: "Django>=3.1,<3.2"
+            python-version: 3.8
+          - wagtail-version: "Wagtail>=2.14,<2.15"
+            django-version: "Django>=3.0,<3.1"
+            python-version: 3.7
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}-${{ matrix.name }}
+          restore-keys: ${{ runner.os }}-pip-
+      - run: |
+          python -m pip install --upgrade pip
+          pip install -e .[test]
+          pip install "${{ matrix.wagtail-version }}"
+          pip install "${{ matrix.django-version }}"
+      - if: ${{ !matrix.latest }}
+        run: pytest
+      - if: ${{ matrix.latest }}
+        run: pytest --junitxml=junit/test-results.xml --cov=wagtail_bucketav
+      - if: ${{ matrix.latest }}
+        uses: codecov/codecov-action@v1
+        with:
+          name: Python 3.9

--- a/manage.py.example
+++ b/manage.py.example
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "wagtail_bucketav.testapp.settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,16 +70,48 @@ name = "wagtail_bucketav"
 [tool.flit.sdist]
 exclude = [
     "wagtail_bucketav/static_src",
-    "wagtail_bucketav/test",
     "wagtail_bucketav/tests",
+    "wagtail_bucketav/testapp",
     "wagtail_bucketav/static/.gitignore",
     "docs",
-    ".*",
     "*.js",
     "*.json",
     "*.ini",
     "*.yml",
+    ".editorconfig"
 ]
 include = [
     "wagtail_bucketav/static"
 ]
+
+[tool.isort]
+known_first_party = "wagtail_bucketav"
+profile = "black"
+skip = "migrations,node_modules,venv"
+sections = "STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
+default_section = "THIRDPARTY"
+multi_line_output = 3
+include_trailing_comma = "True"
+force_grid_wrap = 0
+use_parentheses = "True"
+
+[tool.black]
+line_length = 88
+exclude = '''
+(
+  /(
+      \.eggs
+    | \.git
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | __pycache__
+    | _build
+    | build
+    | dist
+    | docs
+    | venv
+    | node_modules
+  )/
+)
+'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,85 @@
+[build-system]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "wagtail-bucketav"
+authors = [
+    {name = "Jake Howard", email = "jake.howard@torchbox.com"},
+    {name = "Nick Morton", email = "nick.moreton@torchbox.com"},
+    {name = "Joshua Munn", email = "joshua.munn@torchbox.com"},
+    {name = "Andy Babic", email = "andy.babic@torchbox.com"}
+]
+description = ""
+readme = "README.md"
+license = {file = "LICENSE"}
+classifiers = [
+    "Development Status :: 1 - Planning",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Framework :: Django",
+    "Framework :: Django :: 2.2",
+    "Framework :: Django :: 3.2",
+    "Framework :: Django :: 4.0",
+    "Framework :: Wagtail",
+    "Framework :: Wagtail :: 2",
+    "Framework :: Wagtail :: 3"
+]
+dynamic = ["version"]
+requires-python = ">=3.7"
+dependencies = [
+    "Django>=3.0,<4.1",
+    "Wagtail>=2.14,<4.0",
+]
+
+[project.optional-dependencies]
+lint = [
+    "black==22.6.0",
+    "isort==5.10.1",
+    "flake8==3.9.2",
+]
+test = [
+    "pytest-cov==3.0.0",
+    "pytest-mock==3.8.2",
+    "pytest-django==4.5.2",
+    "pytest==7.1.2",
+]
+documentation = [
+    "mkdocs==1.1.2",
+    "mkdocs-material==6.2.8",
+    "mkdocs-mermaid2-plugin==0.5.1",
+    "mkdocstrings==0.14.0",
+    "mkdocs-include-markdown-plugin==2.8.0",
+    "pygments==2.11.2"
+]
+
+[project.urls]
+Home = "https://github.com/torchbox/wagtail-bucketav"
+Source = "https://github.com/torchbox/wagtail-bucketav"
+
+[tool.flit.module]
+name = "wagtail_bucketav"
+
+[tool.flit.sdist]
+exclude = [
+    "wagtail_bucketav/static_src",
+    "wagtail_bucketav/test",
+    "wagtail_bucketav/tests",
+    "wagtail_bucketav/static/.gitignore",
+    "docs",
+    ".*",
+    "*.js",
+    "*.json",
+    "*.ini",
+    "*.yml",
+]
+include = [
+    "wagtail_bucketav/static"
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = wagtail_bucketav.testapp.settings
+python_files = tests.py test_*.py *_tests.py
+testpaths =
+    wagtail_bucketav
+addopts = --tb=short

--- a/wagtail_bucketav/__init__.py
+++ b/wagtail_bucketav/__init__.py
@@ -1,0 +1,5 @@
+__version__ = "0.0.1"
+
+
+def get_version():
+    return __version__

--- a/wagtail_bucketav/apps.py
+++ b/wagtail_bucketav/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class WagtailBucketAVAppConfig(AppConfig):
+    default_auto_field = "django.db.models.AutoField"
+    name = "wagtail_bucketav"

--- a/wagtail_bucketav/test_example.py
+++ b/wagtail_bucketav/test_example.py
@@ -1,0 +1,3 @@
+def test_wagtailadmin_loads_successfully(admin_client):
+    response = admin_client.get("/admin/")
+    assert response.status_code == 200

--- a/wagtail_bucketav/testapp/settings.py
+++ b/wagtail_bucketav/testapp/settings.py
@@ -1,0 +1,92 @@
+import os
+
+from wagtail import VERSION as WAGTAIL_VERSION
+
+PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+ALLOWED_HOSTS = ["*"]
+
+DATABASES = {
+    "default": {
+        "NAME": "wagtail_bucketav-test.sqlite",
+        "ENGINE": "django.db.backends.sqlite3",
+    }
+}
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "default-location",
+    },
+}
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [os.path.join(PROJECT_DIR, "templates")],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    }
+]
+
+INSTALLED_APPS = [
+    "wagtail_bucketav",
+    "wagtail_bucketav.testapp",
+    "modelcluster",
+    "taggit",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "django.contrib.sites",
+    "wagtail.admin",
+    "wagtail" if WAGTAIL_VERSION >= (3, 0) else "wagtail.core",
+    "wagtail.sites",
+    "wagtail.search",
+    "wagtail.users",
+    "wagtail.images",
+    "wagtail.documents",
+    "wagtail.contrib.modeladmin",
+]
+
+MIDDLEWARE = [
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+]
+
+ROOT_URLCONF = "wagtail_bucketav.testapp.urls"
+WAGTAIL_SITE_NAME = "WagtailBucketAV"
+LOGIN_URL = "wagtailadmin_login"
+LOGIN_REDIRECT_URL = "wagtailadmin_home"
+SECRET_KEY = os.getenv("SECRET_KEY", "not-secret-at-all")
+
+# Django i18n
+TIME_ZONE = "Europe/London"
+USE_TZ = True
+
+# Used in Wagtail emails
+BASE_URL = "https://localhost:8000"
+
+# Don't redirect to HTTPS in tests
+SECURE_SSL_REDIRECT = False
+
+# Use default static files storage for tests
+STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+STATIC_ROOT = os.path.join(PROJECT_DIR, "static")
+STATIC_URL = "/static/"
+
+PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
+
+# TODO: Unset when we have some model definitions in testapp.models :)
+# WAGTAILIMAGES_IMAGE_MODEL = "testapp.CustomImage"
+# WAGTAILDOCS_DOCUMENT_MODEL = "testapp.CustomDocument"

--- a/wagtail_bucketav/testapp/urls.py
+++ b/wagtail_bucketav/testapp/urls.py
@@ -1,0 +1,6 @@
+from django.urls import include, path
+
+urlpatterns = [
+    path("admin/", include("wagtail.admin.urls")),
+    path("", include("wagtail.core.urls")),
+]


### PR DESCRIPTION
@RealOrangeOne Here's the basic setup as promised.

A couple of things that we should do before merging these changes:
- [x] Make the repo public so that we can run workflows
- [x] Make any tweaks required to get the basic workflows passing

I've made a couple of assumptions here, which I hope you agree with?
1. We're unlikely to do anything postgres-specific with Django fields in this app, so a basic sqllite DB should be fine for development/testing
2. While we shouldn't rely entirely on coverage as a mark of quality, codecov.io is certainly useful for spotting test gaps on PRs, so we should set up that to get coverage reports for all pushes (I don't think this actually requires any action for public repos)
3. I've added `manage.py.example` to the project root... the intention here is that this will be copied and used to run the `testapp` locally like as regular Wagtail site (using a very simple `virtualenv` setup for dependencies). I expect it's all going to be rather minimal, so can't imagine we'll need anything more complicated than this.

Once merged, next steps should be:
1. Pop your PyPi username / password in as env var values under the 'Settings' tab
4. Create an initial release via https://github.com/torchbox/wagtail-bucketav/releases/ to test the `publish` workflow
5. Make any necessary tweaks to get that workflow working (I've followed the [flit docs](https://flit.pypa.io/en/latest/upload.html) as well as I can, but haven't been able to try publishing via flit yet)
6. Once we have our first version in PyPi, create a project-scoped API token in PyPi and update the `PYPI_PASSWORD` env var to use that (and set `PYPI_USERNAME` to a blank string).
7. [Create another release](https://github.com/torchbox/wagtail-bucketav/releases/) to test that publishing works with the project-scoped API token (I can't actually find any mention of this in the flit docs, but I've got my fingers crossed it'll do the job!)